### PR TITLE
Fixed alert messages that were white

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -8610,5 +8610,23 @@ comments {
 }
 
 .client_channels_list_container {
-    background: red;
+    background: red !important;
+}
+.p-channel_sidebar {
+    background: blue !important;
+}
+
+a, a:link, a:visited {
+    color: #0576b97a;
+}
+.c-member_slug--link {
+    background: #eaf5fc80;
+    color: #0576b9;
+}
+.c-member_slug--link, .c-member_slug--mention {
+    border-radius: 3px;
+    padding: 0 2px 1px 2px;
+}
+.c-member_slug--mention, .c-member_slug--mention:hover {
+    background: #fff6d180;
 }

--- a/dark.css
+++ b/dark.css
@@ -8623,5 +8623,5 @@ a, a:link, a:visited {
 /* fix messages background color */
 
 .c-virtual_list__item, .p-message_pane__limited_history_foreword {
-    background-color: #000000;
+    background-color: #000000 !important;
 }

--- a/dark.css
+++ b/dark.css
@@ -8619,14 +8619,18 @@ comments {
 a, a:link, a:visited {
     color: #0576b97a;
 }
+
+/* color when someone mention a username */
 .c-member_slug--link {
-    background: #eaf5fc80;
-    color: #0576b9;
+    background: #00a0ff;
+    color: #fff;
 }
 .c-member_slug--link, .c-member_slug--mention {
     border-radius: 3px;
     padding: 0 2px 1px 2px;
 }
+/* color when someone mention your username */
 .c-member_slug--mention, .c-member_slug--mention:hover {
-    background: #fff6d180;
+    background: #ffd835;
+    color: #000;
 }

--- a/dark.css
+++ b/dark.css
@@ -8620,17 +8620,8 @@ a, a:link, a:visited {
     color: #0576b97a;
 }
 
-/* color when someone mention a username */
-.c-member_slug--link {
-    background: #084D78;
-    color: #fff !important;
-}
-.c-member_slug--link, .c-member_slug--mention {
-    border-radius: 3px;
-    padding: 0 2px 1px 2px;
-}
-/* color when someone mention your username */
-.c-member_slug--mention, .c-member_slug--mention:hover {
-    background: #f4A4A4A;
-    color: #000 !important;
+/* fix messages background color */
+
+.c-virtual_list__item {
+    background-color: #000000;
 }

--- a/dark.css
+++ b/dark.css
@@ -8623,5 +8623,6 @@ a, a:link, a:visited {
 /* fix messages background color */
 
 .c-virtual_list__item, .p-message_pane__limited_history_foreword {
-    background-color: #000000 !important;
+    background: #222 !important;;
+    color: #a1a1a1 !important;;
 }

--- a/dark.css
+++ b/dark.css
@@ -8623,6 +8623,10 @@ a, a:link, a:visited {
 /* fix messages background color */
 
 .c-virtual_list__item, .p-message_pane__limited_history_foreword {
-    background: #222 !important;;
-    color: #a1a1a1 !important;;
+    background: #222 !important;
+    color: #a1a1a1 !important;
+}
+
+.p-message_pane__limited_history_foreword_headline {
+    color: #a1a1a1 !important;
 }

--- a/dark.css
+++ b/dark.css
@@ -8622,7 +8622,7 @@ a, a:link, a:visited {
 
 /* color when someone mention a username */
 .c-member_slug--link {
-    background: #00a0ff;
+    background: #084D78;
     color: #fff !important;
 }
 .c-member_slug--link, .c-member_slug--mention {
@@ -8631,6 +8631,6 @@ a, a:link, a:visited {
 }
 /* color when someone mention your username */
 .c-member_slug--mention, .c-member_slug--mention:hover {
-    background: #ffd835;
+    background: #f4A4A4A;
     color: #000 !important;
 }

--- a/dark.css
+++ b/dark.css
@@ -8622,6 +8622,6 @@ a, a:link, a:visited {
 
 /* fix messages background color */
 
-.c-virtual_list__item {
+.c-virtual_list__item, .p-message_pane__limited_history_foreword {
     background-color: #000000;
 }

--- a/dark.css
+++ b/dark.css
@@ -8610,10 +8610,10 @@ comments {
 }
 
 .client_channels_list_container {
-    background: red !important;
+    background: black !important;
 }
 .p-channel_sidebar {
-    background: blue !important;
+    background: black !important;
 }
 
 a, a:link, a:visited {

--- a/dark.css
+++ b/dark.css
@@ -8623,7 +8623,7 @@ a, a:link, a:visited {
 /* color when someone mention a username */
 .c-member_slug--link {
     background: #00a0ff;
-    color: #fff;
+    color: #fff !important;
 }
 .c-member_slug--link, .c-member_slug--mention {
     border-radius: 3px;
@@ -8632,5 +8632,5 @@ a, a:link, a:visited {
 /* color when someone mention your username */
 .c-member_slug--mention, .c-member_slug--mention:hover {
     background: #ffd835;
-    color: #000;
+    color: #000 !important;
 }

--- a/dark.css
+++ b/dark.css
@@ -8608,3 +8608,7 @@ comments {
     position: absolute;
     right: 0;
 }
+
+.client_channels_list_container {
+    background: red;
+}


### PR DESCRIPTION
Hi! I fixed alert messages that were white, now they match the dark theme.
<img width="952" alt="screen shot 2018-10-20 at 12 42 44" src="https://user-images.githubusercontent.com/542722/47257570-f4e16e00-d465-11e8-84af-c6562aee9f46.png">
