### PR TITLE
White history loading on Slack for Linux

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -8694,6 +8694,10 @@ a, a:link, a:visited {
     color: lightgray;
 }
 
+.c-reaction_add {
+    background: #a1a1a1;
+}
+
 .c-search_message__body{
     color: lightgray;
 }

--- a/dark.css
+++ b/dark.css
@@ -333,6 +333,10 @@ h1, h2, h3, h4 {
     color: #949494;
 }
 
+.p-degraded_list__loading {
+    background-color: #222;
+}
+
 .infinite_spinner_bg, .infinite_spinner_blue {
     stroke: #a1a1a1;
 }


### PR DESCRIPTION
Hi,

I saw that the "Loading history..." label is still showing a white background. I tried to resolve this issue by adding a new rule in the css file.

## Before
![white-loading-history](https://user-images.githubusercontent.com/18450669/60519434-36603380-9cec-11e9-9e87-6fc26c212b10.png)

## After
![fix-white-loading-history](https://user-images.githubusercontent.com/18450669/60519448-3ceeab00-9cec-11e9-9180-27cee70c3d46.png)
