### PR TITLE
Fix share modale dialog

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -8958,3 +8958,38 @@ span.c-message__sender.c-message_kit__sender {
 .p-file_details__share_channel, .p-file_details__name {
     color: inherit;
 }
+
+.c-alert--inline, .c-texty_input .ql-placeholder {
+    color: #a1a1a1;
+}
+
+.c-alert--level_warning {
+    background-color: #333;
+    border: 1px solid #a1a1a1;
+}
+
+.c-message_attachment__author_name {
+    color: #a1a1a1 !important;
+}
+
+.c-dialog__content {
+    background: #222;
+}
+
+.c-texty_input.c-texty_input--use_focus_ring.focus {
+    box-shadow: 0 0 0 1px #333, 0 0 0 5px #333;
+}
+
+.c-dialog_speed_bump_overlay {
+    background: hsla(0,0%,13.33%,.7);
+}
+
+.c-dialog_speed_bump {
+    background-color: #222;
+    border-top: 1px solid #444;
+}
+
+.c-dialog_speed_bump__button_row .c-button--outline {
+    background: #424242;
+    color: #a1a1a1;
+}

--- a/dark.css
+++ b/dark.css
@@ -8825,8 +8825,8 @@ span.c-message__sender.c-message_kit__sender {
     }
 
 .c-input_select_options_list_container {
-    background: #222 !important;
-    border-color: #222 !important;
+    background: #444 !important;
+    border-color: #444 !important;
 }
 
     .c-input_select_options_list_container .c-input_select_options_list__option {
@@ -8990,6 +8990,27 @@ span.c-message__sender.c-message_kit__sender {
 }
 
 .c-dialog_speed_bump__button_row .c-button--outline {
+    background: #545454;
+    color: #a1a1a1;
+}
+
+.c-input_select {
+    background: #545454;
+}
+
+.c-dialog__body input[type=text]:focus {
+    box-shadow: none;
+}
+
+.c-dialog__body .c-input_select--active {
+    box-shadow: 0 0 0 1px #333, 0 0 0 5px #333;
+}
+
+.c-input_select__secondary_member_name {
+    color: #fff;
+}
+
+.c-dialog__footer .c-button {
     background: #424242;
     color: #a1a1a1;
 }


### PR DESCRIPTION
1. When sharing a message from a one-to-one chat
*Before*
![before1](https://user-images.githubusercontent.com/18450669/61787731-13bbc900-ae19-11e9-819e-74b8e4104288.png)
*After*
![after1](https://user-images.githubusercontent.com/18450669/61787743-18807d00-ae19-11e9-87cc-53802396dfc5.png)

2. When sharing a message from a public channel
*Before*
![before2](https://user-images.githubusercontent.com/18450669/61787775-2930f300-ae19-11e9-9473-f9a9402033fd.png)
*After*
![after2](https://user-images.githubusercontent.com/18450669/61787784-2cc47a00-ae19-11e9-9daf-d2a24d8bafaf.png)

3. When a message is present and Escape is pressed
*Before*
![before3](https://user-images.githubusercontent.com/18450669/61787844-5382b080-ae19-11e9-80de-aff0b7ef4f7e.png)
*After*
![after3](https://user-images.githubusercontent.com/18450669/61787848-58476480-ae19-11e9-8086-7616940c654f.png)